### PR TITLE
Update constexpr to use variadic templates for clang support

### DIFF
--- a/cpp/deps.txt
+++ b/cpp/deps.txt
@@ -1,2 +1,2 @@
 https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip -DJSON_BuildTests=OFF
-https://github.com/cucumber/messages/archive/refs/heads/main.zip --src-dir=cpp
+https://github.com/krishnangovindraj/cucumber-messages/archive/refs/heads/main.zip --src-dir=cpp

--- a/cpp/deps.txt
+++ b/cpp/deps.txt
@@ -1,2 +1,2 @@
 https://github.com/nlohmann/json/archive/refs/tags/v3.11.2.zip -DJSON_BuildTests=OFF
-https://github.com/krishnangovindraj/cucumber-messages/archive/refs/heads/main.zip --src-dir=cpp
+https://github.com/vaticle/cucumber-messages/archive/refs/heads/main.zip --src-dir=cpp

--- a/cpp/include/gherkin/type_traits.hpp
+++ b/cpp/include/gherkin/type_traits.hpp
@@ -5,15 +5,15 @@ namespace gherkin {
 namespace detail {
 
 template <
-    template <typename> class Container,
-    template <typename> class Other,
+    template <typename ...> class Container,
+    template <typename ...> class Other,
     typename T
 >
 std::is_same<Container<T>, Other<T>>
 test_is_container(Other<T>*);
 
 template <
-    template <typename> class Container,
+    template <typename ...> class Container,
     typename T
 >
 std::false_type test_is_container(T*);
@@ -21,7 +21,7 @@ std::false_type test_is_container(T*);
 } // namespace detail
 
 template <
-    template <typename> class C,
+    template <typename ...> class C,
     typename T
 >
 using is_container = decltype(
@@ -29,7 +29,7 @@ using is_container = decltype(
 );
 
 template <
-    template <typename> class C,
+    template <typename ...> class C,
     typename T
 >
 inline

--- a/cpp/include/gherkin/utils.hpp
+++ b/cpp/include/gherkin/utils.hpp
@@ -4,6 +4,7 @@
 #include <string>
 #include <string_view>
 #include <regex>
+#include <locale>
 
 namespace gherkin {
 

--- a/cpp/scripts/build-ext
+++ b/cpp/scripts/build-ext
@@ -35,6 +35,7 @@ done
 #
 ###############################################################################
 BUILDROOT=$MYDIR/build/root
+# Why do we override these?
 CC=
 CFLAGS=
 CXX=

--- a/cpp/scripts/build-ext
+++ b/cpp/scripts/build-ext
@@ -35,7 +35,6 @@ done
 #
 ###############################################################################
 BUILDROOT=$MYDIR/build/root
-# Why do we override these?
 CC=
 CFLAGS=
 CXX=


### PR DESCRIPTION
## What is the goal of this PR?
Update `constexpr`'s to use variadic templates  for clang compatibility.

## What are the changes implemented in this PR?
* Update `constexpr`'s to use variadic templates  for clang compatibility.
* Points cucumber messages dependency to `vaticle/cucumber-messages`
* Adds a header for compatibility. 